### PR TITLE
Adding ability to read from gzip or zip files

### DIFF
--- a/apple2Setup.go
+++ b/apple2Setup.go
@@ -72,7 +72,7 @@ const (
 
 // LoadRom loads a standard Apple2+ or 2e ROM
 func (a *Apple2) LoadRom(filename string) error {
-	data, err := storage.LoadResource(filename)
+	data, _, err := storage.LoadResource(filename)
 	if err != nil {
 		return err
 	}

--- a/base64a.go
+++ b/base64a.go
@@ -36,7 +36,7 @@ func loadBase64aRom(a *Apple2) error {
 
 	for i := 0; i < base64aRomChipCount; i++ {
 		filename := fmt.Sprintf("<internal>/BASE64A_%X.BIN", 0xd0+i*0x08)
-		data, err := storage.LoadResource(filename)
+		data, _, err := storage.LoadResource(filename)
 		if err != nil {
 			return err
 		}

--- a/cardBase.go
+++ b/cardBase.go
@@ -39,7 +39,7 @@ func (c *cardBase) reset() {
 }
 
 func (c *cardBase) loadRomFromResource(resource string) {
-	data, err := storage.LoadResource(resource)
+	data, _, err := storage.LoadResource(resource)
 	if err != nil {
 		// The resource should be internal and never fail
 		panic(err)

--- a/characterGenerator.go
+++ b/characterGenerator.go
@@ -45,7 +45,7 @@ func newCharacterGenerator(filename string, order charColumnMap) (*CharacterGene
 }
 
 func (cg *CharacterGenerator) load(filename string) error {
-	bytes, err := storage.LoadResource(filename)
+	bytes, _, err := storage.LoadResource(filename)
 	if err != nil {
 		return err
 	}

--- a/storage/diskette.go
+++ b/storage/diskette.go
@@ -14,7 +14,7 @@ type Diskette interface {
 
 // IsDiskette returns true if the files looks like a 5 1/4 diskette
 func IsDiskette(filename string) bool {
-	data, err := LoadResource(filename)
+	data, _, err := LoadResource(filename)
 	if err != nil {
 		return false
 	}
@@ -24,7 +24,7 @@ func IsDiskette(filename string) bool {
 
 // LoadDiskette returns a Diskette by detecting the format
 func LoadDiskette(filename string) (Diskette, error) {
-	data, err := LoadResource(filename)
+	data, writeable, err := LoadResource(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -32,12 +32,14 @@ func LoadDiskette(filename string) (Diskette, error) {
 	if isFileNib(data) {
 		var d diskette16sector
 		d.nib = newFileNib(data)
+		d.nib.supportsWrite = d.nib.supportsWrite && writeable
 		return &d, nil
 	}
 
 	if isFileDsk(data) {
 		var d diskette16sectorWritable
 		d.nib = newFileDsk(data, filename)
+		d.nib.supportsWrite = d.nib.supportsWrite && writeable
 		return &d, nil
 	}
 

--- a/storage/resources.go
+++ b/storage/resources.go
@@ -29,66 +29,72 @@ func isHTTPResource(filename string) bool {
 }
 
 // LoadResource loads in memory a file from the filesystem, http or embedded
-func LoadResource(filename string) ([]uint8, error) {
+func LoadResource(filename string) ([]uint8, bool, error) {
+	var writeable bool
 	var file io.Reader
 	if isInternalResource(filename) {
 		// load from embedded resource
 		resource := strings.TrimPrefix(filename, internalPrefix)
 		resourceFile, err := romdumps.Assets.Open(resource)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		defer resourceFile.Close()
 		file = resourceFile
+		writeable = false
 
 	} else if isHTTPResource(filename) {
 		response, err := http.Get(filename)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		defer response.Body.Close()
 		file = response.Body
+		writeable = false
 
 	} else {
 		diskFile, err := os.Open(filename)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		defer diskFile.Close()
 		file = diskFile
+		writeable = true
 	}
 
 	data, err := ioutil.ReadAll(file)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	contentType := http.DetectContentType(data)
 	if contentType == "application/x-gzip" {
+		writeable = false
 		gz, err := gzip.NewReader(bytes.NewReader(data))
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		defer gz.Close()
 		data, err = ioutil.ReadAll(gz)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 	} else if contentType == "application/zip" {
+		writeable = false
 		z, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		for _, zf := range z.File {
 			f, err := zf.Open()
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			defer f.Close()
 			bytes, err := ioutil.ReadAll(f)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			if isFileDsk(bytes) || isFileNib(bytes) || isFileWoz(bytes) {
 				data = bytes
@@ -97,5 +103,5 @@ func LoadResource(filename string) ([]uint8, error) {
 		}
 	}
 
-	return data, nil
+	return data, writeable, nil
 }


### PR DESCRIPTION
I have a number of disk images that are in an archive, and it gets annoying to decompress them. So, after a quick bit of 'googling', I saw that it was relatively simple to identify file types. 

This PR adds the ability to load a disk "still" in gzip or zip format. For the zip file, I reused the `isFile*(...)` methods to locate the first disk image in the archive.

After adding the code, I realized that `LoadResource(...)` is used in multiple locations to load any remote resource. If you think that may be a problem (or this should be restructured), please let me know!