### PR TITLE
fix disk b index for sequencer drive

### DIFF
--- a/apple2Setup.go
+++ b/apple2Setup.go
@@ -126,7 +126,7 @@ func (a *Apple2) AddDisk2Sequencer(slot int, diskImage, diskBImage string, track
 	}
 
 	if diskBImage != "" {
-		err := c.drive[0].insertDiskette(diskBImage)
+		err := c.drive[1].insertDiskette(diskBImage)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Disk B for sequencer drive was using index 0 instead of 1, so both -disk and -diskb were setting the first disk.