### PR TITLE
replace a deprecated Fyne call and make the Device Panel scrollable

### DIFF
--- a/frontend/a2fyne/main.go
+++ b/frontend/a2fyne/main.go
@@ -14,6 +14,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/layout"
 )
@@ -66,7 +67,7 @@ func fyneRun(s *state) {
 	display.ScaleMode = canvas.ImageScalePixels // Looks worst but loads less.
 	display.SetMinSize(fyne.NewSize(280, 192))
 
-	container := fyne.NewContainerWithLayout(
+	container := container.New(
 		layout.NewBorderLayout(nil, toolbar, nil, s.devices.w),
 		display, toolbar, s.devices.w,
 	)

--- a/frontend/a2fyne/panelDevices.go
+++ b/frontend/a2fyne/panelDevices.go
@@ -14,17 +14,20 @@ type panelDevices struct {
 func newPanelDevices(s *state) *panelDevices {
 	var pd panelDevices
 	pd.s = s
-	pd.w = container.NewVBox()
+	pd.w = container.NewMax()
+	c := container.NewVBox()
 
 	pd.joystick = newPanelJoystick()
-	pd.w.Add(pd.joystick.w)
+	c.Add(pd.joystick.w)
 
 	var cards = s.a.GetCards()
 	for i, card := range cards {
 		if card != nil && card.GetName() != "" {
-			pd.w.Add(newPanelCard(i, card).w)
+			c.Add(newPanelCard(i, card).w)
 		}
 	}
+
+	pd.w.Add(container.NewVScroll(c))
 
 	return &pd
 }


### PR DESCRIPTION
Using the Fyne frontend, when the device panel (particularly on a MacBook) is opened, it causes the whole window to resize to fit the entire list of cards. This causes the main window to be too big to fit on the screen and you can no longer access the toolbar to turn the panel back off. 
This patch wraps the contents of the device panel in a scrollable pane.
I've also replaced the deprecated 'fyne.NewContainerWithLayout' with 'container.New' in the Fyne main.go.
