### PR TITLE
Adding ability to use a custom model

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ The available pre-configured models are:
   prodos: Apple //e Prodos
   swyft: swyft
   ultraterm: Apple ][+ with Videx Ultraterm demo
+Custom models may be specified by filename.  Use 'IZAPPLE2_CUSTOM_MODEL' to set default location.
 
 The available cards are:
   brainboard: Firmware card. It has two ROM banks

--- a/doc/usage.txt
+++ b/doc/usage.txt
@@ -62,6 +62,7 @@ The available pre-configured models are:
   prodos: Apple //e Prodos
   swyft: swyft
   ultraterm: Apple ][+ with Videx Ultraterm demo
+Custom models may be specified by filename.  Use 'IZAPPLE2_CUSTOM_MODEL' to set default location.
 
 The available cards are:
   brainboard: Firmware card. It has two ROM banks


### PR DESCRIPTION
Basically reuses the model configuration file, but from the filesystem.

I happened to catch the new `pascal.cfg` file that was added from my other ticket... and thought it would be nifty to just use my own configurations!

Samples:

800K Apple Pascal development:

```
name: Apple //e with Apple Pascal 1.3 for development - 800K disks
parent: 2enh
s5: prodosblock,image1="/home/rob/Apple2/Disks/Pascal Data.po"
s6: prodosblock,image1="/home/rob/Apple2/Disks/Apple Pascal 1.3 3.5 WORK DISK.po"
```

140K Apple Pascal development (note that APPLE0 was replaced in S5,D2):

```
name: Apple //e with Apple Pascal 1.3 for development
parent: 2enh
s5: diskii,disk1="<internal>/Apple II Pascal 1.3 APPLE3_ 680-0290-A.dsk",disk2="/home/rob/Apple2/Disks/pascal-data-140.dsk"
s6: diskii,disk1="<internal>/Apple II Pascal 1.3 APPLE1_ 680-0283-A.dsk",disk2="<internal>/Apple II Pascal 1.3 APPLE2_ 680-0284-A.dsk"
```

Pondering if an environment variable should be added to have a custom configuration directory.

Testing was just:

```shell
$ ./a2sdl -model p800k.cfg 
```
