### PR TITLE
Adding ability to use shift+insert to paste text into emulator.

### DIFF
--- a/frontend/a2sdl/sdlKeyboard.go
+++ b/frontend/a2sdl/sdlKeyboard.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ivanizag/izapple2"
 	"github.com/ivanizag/izapple2/screen"
@@ -136,6 +137,11 @@ func (k *sdlKeyboard) putKey(keyEvent *sdl.KeyboardEvent) {
 		}
 	case sdl.K_PAUSE:
 		k.a.SendCommand(izapple2.CommandPauseUnpause)
+	case sdl.K_INSERT:
+		if shift {
+			text, _ := sdl.GetClipboardText()
+			go k.performPaste(text)
+		}
 	}
 
 	// Missing values 91 to 95. Usually control for [\]^_
@@ -143,5 +149,18 @@ func (k *sdlKeyboard) putKey(keyEvent *sdl.KeyboardEvent) {
 
 	if result != 0 {
 		k.keyChannel.PutChar(result)
+	}
+}
+
+func (k *sdlKeyboard) performPaste(text string) {
+	// Note 1: Pasting is too fast, so we slow it down.
+	// Note 2: Need to translate CR/LF's
+	for _, ch := range text {
+		if ch == '\r' || ch == '\n' {
+			k.keyChannel.PutChar(13)
+		} else {
+			k.keyChannel.PutRune(ch)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
I didn't find a way to paste text into the emulator, so I added that capability. Note that I kept losing text if there was no delay. The 20ms delay seemed to be the closest I could get without losing text. It also needed to be in a go routine in order to be able to actually watch the text being pasted in.

As an aside, I have a tool that generates Applesoft code with embedded binaries, and one of the output options is to allow pasting the program in -- sometimes faster than making a disk and loading it into the emulator... so if you want to test, this is what I used. (Obviously, `call -151` first!)

```
0067:01 08 7B 08 
0800:00 
0801:0A 08 0A 00 B0 31 30 30 00 13 08 14 00 91 3A 92 
0811:33 00 22 08 1E 00 94 4D C5 31 30 30 2C 31 30 30 
0821:00 28 08 28 00 80 00 79 08 64 00 B9 32 33 32 2C 
0831:37 39 3A B9 32 33 33 2C 38 3A 98 30 3A 99 31 3A 
0841:41 44 D0 32 31 32 37 3A 4D D0 31 3A B1 00 01 00 
0851:04 00 36 2E 36 2D 1C D7 3F 3F 3F 2C 2D 2D 3C 3F 
0861:3F 37 1C 37 37 2E 2E 35 2D 2C C4 40 28 2D FC 3F 
0871:3E 67 4D 41 09 04 00 00 00 00 
```

This is just a simple program that includes a mouse shape I made in the 1980's for some competition and draws it on the screen.