### PR TITLE
Find the apple keys by scancode on SDL3

### DIFF
--- a/frontend/a2sdl3/main.go
+++ b/frontend/a2sdl3/main.go
@@ -109,6 +109,8 @@ func sdlRun(a *izapple2.Apple2) {
 				e := event.KeyboardEvent()
 				kp.putKey(e)
 				j.putKey(e)
+			case sdl.EVENT_WINDOW_FOCUS_LOST:
+				j.releaseKeys()
 			case sdl.EVENT_TEXT_INPUT:
 				kp.putText(event.TextInputEvent().Text)
 			case sdl.EVENT_JOYSTICK_AXIS_MOTION:

--- a/frontend/a2sdl3/sdl3Joysticks.go
+++ b/frontend/a2sdl3/sdl3Joysticks.go
@@ -132,16 +132,28 @@ func (j *sdl3Joysticks) putKey(keyEvent *sdl.KeyboardEvent) {
 		   Alt key - button 0 - Open apple
 		   AltGr key - button 1- Solid apple
 		   //Win key - button 2 (Not in the Apple //e keyboard)
+
+		The apple keys are a place on the keyboard, not a symbol, so we look at
+		the scancode. Unlike SDL2, SDL3 resolves the keycode through the current
+		keymap: on layouts where the left alt key is Meta_L instead of Alt_L the
+		keycode is not K_LALT and the open apple would never be pressed.
 	*/
-	switch keyEvent.Key {
-	case sdl.K_LALT:
+	switch keyEvent.Scancode {
+	case sdl.SCANCODE_LALT:
 		j.keys[0] = keyEvent.Down
-	case sdl.K_RALT:
+	case sdl.SCANCODE_RALT:
 		j.keys[1] = keyEvent.Down
-		// case sdl.K_LGUI:
+		// case sdl.SCANCODE_LGUI:
 		//   j.keys[2] = keyEvent.Down
 	}
 
+}
+
+// releaseKeys forgets the apple keys being pressed. The key up event of a key
+// held while the window loses the focus goes to whoever took it, leaving the
+// apple key pressed forever.
+func (j *sdl3Joysticks) releaseKeys() {
+	j.keys = [3]bool{}
 }
 
 func (j *sdl3Joysticks) ReadButton(i int) bool {


### PR DESCRIPTION
Fixes the open apple key not working on the SDL3 frontend, reported in #44.

## The problem

`sdl3Joysticks.putKey()` was a direct port of the SDL2 code and identified the apple keys by keycode:

```go
switch keyEvent.Key {
case sdl.K_LALT:
```

The meaning of that field changed between SDL2 and SDL3. SDL3 resolves the keycode through the current keymap, taking the layout and the modifier state into account, while SDL2 took it from the scancode for the non printable keys. On the layouts where the left alt key carries `Meta_L` instead of `Alt_L`, common on Linux, SDL3 reports `K_LGUI` and the `case sdl.K_LALT` never matches: the open apple key does nothing.

The open and solid apple keys are a place on the keyboard and not a symbol, so this looks at the scancode now. That is what the SDL3 [keyboard guidance](https://wiki.libsdl.org/SDL3/BestKeyboardPractices) recommends for physical key positions.

The SDL2 frontend is left alone, its keycodes for the modifiers come from the scancode already.

## Also here

The apple keys are now forgotten when the window loses the focus. The key up event of a key held while alt-tabbing away goes to whoever took the focus, so the apple key stayed pressed forever. The SDL2 frontend has the same issue, not touched here.

## Testing

Verified on macOS with an Applesoft program polling $C061 to $C063: the open and solid apple keys still read as pressed, and they now go back to released after alt-tabbing away while held.

The Linux case that triggered the report cannot be reproduced on a Mac, there is no xkb layer to put `Meta_L` on the left alt key. It needs a confirmation from the reporter of #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)